### PR TITLE
Fix using env context while setting environment variables

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -6,7 +6,7 @@ on:
 name: Release Dev
 
 env:
-  TARBALL: microsoft-teams-app-dev-${{ env.GITHUB_SHA }}.tar.gz
+  TARBALL: microsoft-teams-app-dev-${{ github.sha }}.tar.gz
   S3_PATH: ${{ secrets.S3_PATH_DEV }}
   AWS_REGION: ${{ secrets.AWS_REGION_DEV }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
@@ -16,7 +16,7 @@ env:
   AWS_APP_ID: ${{ secrets.AWS_APP_ID_DEV }}
   NEXT_PUBLIC_BASE_URL: ${{ secrets.NEXT_PUBLIC_BASE_URL_DEV }}
   NEXT_PUBLIC_DOMAIN: ${{ secrets.NEXT_PUBLIC_DOMAIN_DEV }}
-  NEXT_PUBLIC_VERSION: 0.0.0-${{ env.GITHUB_SHA }}
+  NEXT_PUBLIC_VERSION: 0.0.0-${{ github.sha }}
   NEXT_PUBLIC_PORT: ${{ secrets.NEXT_PUBLIC_PORT_DEV }}
 
 

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -6,7 +6,7 @@ on:
 name: Release Production
 
 env:
-  TARBALL: microsoft-teams-app-prod--${{ env.GITHUB_REF }}.tar.gz
+  TARBALL: microsoft-teams-app-prod--${{ github.ref }}.tar.gz
   S3_PATH: ${{ secrets.S3_PATH_PROD }}
   AWS_REGION: ${{ secrets.AWS_REGION_PROD }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY_PROD }}


### PR DESCRIPTION
We can't use the context `env` while setting the `env`. 🙁 

Bug: https://github.com/zeplin/microsoft-teams-app/actions/runs/184292809