### PR TITLE
Remove `userId` from grouping key

### DIFF
--- a/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/NotificationHandler.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/NotificationHandler.ts
@@ -7,13 +7,8 @@ export abstract class NotificationHandler {
     getGroupingKey(event: WebhookEvent): string {
         const {
             event: eventType,
-            action,
-            actor: {
-                user: {
-                    id: userId
-                }
-            }
+            action
         } = event.payload;
-        return `${event.webhookId}:${eventType}:${action}:${userId}`;
+        return `${event.webhookId}:${eventType}:${action}`;
     }
 }


### PR DESCRIPTION
We don't group the notifications by user but event type and action in common scenarios. We'll handle `notes` and `replies` differently since we want to send them immediately without grouping.