### PR TITLE
Do not handle `deleted` events

### DIFF
--- a/src/server/features/messagingFeature/messageFacade/messageFacade.test.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacade.test.ts
@@ -55,6 +55,7 @@ const exampleJobData = {
 const mockNotificationHandler = {
     delay: expectedDelay,
     getGroupingKey: jest.fn().mockReturnValue(expectedGroupingKey),
+    shouldHandleEvent: jest.fn().mockReturnValue(true),
     getTeamsMessage: jest.fn().mockReturnValue({
         text: "gol"
     })
@@ -94,6 +95,12 @@ describe("messageFacade", () => {
             }, {
                 delay: expectedDelay
             });
+        });
+
+        it("should not handle event when notificationHandler.shouldReturnEvent returns false", async () => {
+            mockNotificationHandler.shouldHandleEvent.mockReturnValueOnce(false);
+            await messageFacade.handleEventArrived(exampleEvent);
+            expect(mockNotificationHandler.getGroupingKey).not.toBeCalled();
         });
     });
 

--- a/src/server/features/messagingFeature/messageFacade/messageFacade.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacade.ts
@@ -34,6 +34,10 @@ class MessageFacade {
 
     async handleEventArrived(event: WebhookEvent): Promise<void> {
         const notificationHandler = getNotificationHandler(event.payload.event);
+        if (!notificationHandler.shouldHandleEvent(event)) {
+            return;
+        }
+
         const groupingKey = notificationHandler.getGroupingKey(event);
         const jobId = event.deliveryId;
 

--- a/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/NotificationHandler.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/NotificationHandler.ts
@@ -4,6 +4,7 @@ import { AdaptiveCard } from "./teamsCardTemplates";
 export abstract class NotificationHandler {
     abstract get delay(): number;
     abstract getTeamsMessage(events: WebhookEvent[]): AdaptiveCard;
+    abstract shouldHandleEvent(event: WebhookEvent): boolean;
     getGroupingKey(event: WebhookEvent): string {
         const {
             event: eventType,

--- a/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/projectColorNotificationHandler/projectColorNotificationHandler.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/projectColorNotificationHandler/projectColorNotificationHandler.ts
@@ -87,6 +87,10 @@ class ProjectColorNotificationHandler extends NotificationHandler {
         return `${ZEPLIN_MAC_APP_URL_SCHEME}colors?pid=${projectId}&cids=${events.map(event => event.payload.resource.id).join(",")}`;
     }
 
+    shouldHandleEvent(event: WebhookEvent): boolean {
+        return event.payload.action !== "deleted";
+    }
+
     getTeamsMessage(
         events: WebhookEvent<ProjectColorEventPayload>[]
     ): AdaptiveCard {

--- a/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/styleguideColorNotificationHandler/styleguideColorNotificationHandler.ts
+++ b/src/server/features/messagingFeature/messageFacade/messageFacadeNotificationHandlers/styleguideColorNotificationHandler/styleguideColorNotificationHandler.ts
@@ -87,6 +87,10 @@ class StyleguideColorNotificationHandler extends NotificationHandler {
         return `${ZEPLIN_MAC_APP_URL_SCHEME}colors?stid=${styleguideId}&cids=${events.map(event => event.payload.resource.id).join(",")}`;
     }
 
+    shouldHandleEvent(event: WebhookEvent): boolean {
+        return event.payload.action !== "deleted";
+    }
+
     getTeamsMessage(
         events: WebhookEvent<StyleguideColorEventPayload>[]
     ): AdaptiveCard {


### PR DESCRIPTION
Since webhook events will contain all kinds of events; we need to decide whether we want to handle those events or not early in the processing flow to not introduce unnecessary work (grouping some events even though we won't send notification for them). For that, I've added a `shouldHandleEvent` function to `NotificationHandler` and we'll implement it for all kind of notification handlers.