### PR TITLE
Complete resource dropdown

### DIFF
--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -1,2 +1,0 @@
-/* eslint-disable no-process-env */
-export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;

--- a/src/client/containers/HomeContainer/HomeContainer.test.tsx
+++ b/src/client/containers/HomeContainer/HomeContainer.test.tsx
@@ -21,10 +21,6 @@ jest.mock("@microsoft/teams-js", () => ({
     }
 }));
 
-jest.mock("../../config", () => ({
-    BASE_URL: "https://test.com"
-}));
-
 jest.mock("next/router", () => ({
     useRouter: (): object => ({
         query: {

--- a/src/client/containers/HomeContainer/components/Configuration/Configuration.tsx
+++ b/src/client/containers/HomeContainer/components/Configuration/Configuration.tsx
@@ -1,26 +1,34 @@
 import React, { FunctionComponent } from "react";
 import { Flex, Text } from "@fluentui/react-northstar";
-import { Resource, ResourceType, Workspace } from "../../../../requester";
+import {
+    Project, Resource, ResourceType, Styleguide, Workspace
+} from "../../../../requester";
 import { WorkspaceDropdown } from "./WorkspaceDropdown";
 import { ResourceDropdown } from "./ResourceDropdown";
 import { WebhookEvents } from "./WebhookEvents";
 
 interface ConfigurationProps {
     channelName: string;
-    isWorkspacesLoading: boolean;
+    areWorkspacesLoading: boolean;
     workspaces: Workspace[];
     isWorkspaceSelected: boolean;
     resourceType: ResourceType;
+    areResourcesLoading: boolean;
+    projects: Project[];
+    styleguides: Styleguide[];
     onWorkspaceChange: (value: string) => void;
     onResourceChange: (value: Resource | undefined) => void;
 }
 
 export const Configuration: FunctionComponent<ConfigurationProps> = ({
     channelName,
-    isWorkspacesLoading,
+    areWorkspacesLoading,
     workspaces,
     isWorkspaceSelected,
     resourceType,
+    areResourcesLoading,
+    projects,
+    styleguides,
     onWorkspaceChange,
     onResourceChange
 }) => (
@@ -51,7 +59,7 @@ export const Configuration: FunctionComponent<ConfigurationProps> = ({
                 <Flex.Item grow shrink={0} styles={{ flexBasis: 0 }}>
                     <div>
                         <WorkspaceDropdown
-                            loading={isWorkspacesLoading}
+                            loading={areWorkspacesLoading}
                             workspaces={workspaces}
                             onChange={onWorkspaceChange}
                         />
@@ -59,7 +67,12 @@ export const Configuration: FunctionComponent<ConfigurationProps> = ({
                 </Flex.Item>
                 <Flex.Item grow shrink={0} styles={{ flexBasis: 0 }}>
                     <div>
-                        <ResourceDropdown disabled={!isWorkspaceSelected} onChange={onResourceChange} />
+                        <ResourceDropdown
+                            loading={areResourcesLoading}
+                            projects={projects}
+                            styleguides={styleguides}
+                            disabled={!isWorkspaceSelected}
+                            onChange={onResourceChange} />
                     </div>
                 </Flex.Item>
             </Flex>

--- a/src/client/containers/HomeContainer/components/Configuration/ResourceDropdown.tsx
+++ b/src/client/containers/HomeContainer/components/Configuration/ResourceDropdown.tsx
@@ -1,63 +1,60 @@
 import React, { FunctionComponent, ReactElement } from "react";
 import { Divider, Dropdown } from "@fluentui/react-northstar";
-import { Resource, ResourceType } from "../../../../requester";
+import { Project, Resource, ResourceType, Styleguide } from "../../../../requester";
 
 interface ResourceDropdownProps {
     disabled: boolean;
+    loading: boolean;
+    projects: Project[];
+    styleguides: Styleguide[];
     onChange: (value: Resource | undefined) => void;
 }
 
 export const ResourceDropdown: FunctionComponent<ResourceDropdownProps> = ({
     disabled,
+    loading,
+    projects,
+    styleguides,
     onChange
 }) => (
     <Dropdown
         disabled={disabled}
+        loading={loading}
+        loadingMessage="Loading..."
         fluid
         checkable
         items={ [
-            {
+            projects.length > 0 && {
                 header: "Projects",
                 disabled: true,
                 styles: {
                     "font-weight": "bolder"
                 }
             },
-            {
-                header: "Project 1",
+            ...projects.map(({ id, name }) => ({
+                header: name,
                 onClick: (): void => {
-                    onChange({ type: ResourceType.PROJECT, id: "id1" });
+                    onChange({ type: ResourceType.PROJECT, id });
                 }
-            },
-            {
-                header: "Project 2",
-                onClick: (): void => {
-                    onChange({ type: ResourceType.PROJECT, id: "id2" });
-                }
-            },
-            {
+            })),
+            projects.length > 0 && styleguides.length > 0 && {
+                header: "Seperator",
                 as: (): ReactElement => <Divider />,
                 disabled: true
             },
-            {
+            styleguides.length > 0 && {
                 header: "Styleguides",
                 disabled: true,
                 styles: {
                     "font-weight": "bolder"
                 }
             },
-            {
-                header: "Styleguide 1",
+            ...styleguides.map(({ id, name }) => ({
+                header: name,
                 onClick: (): void => {
-                    onChange({ type: ResourceType.STYLEGUIDE, id: "id1" });
+                    onChange({ type: ResourceType.STYLEGUIDE, id });
                 }
-            },
-            {
-                header: "Styleguide 2",
-                onClick: (): void => {
-                    onChange({ type: ResourceType.STYLEGUIDE, id: "id2" });
-                }
-            }
+            }))
         ]}
         placeholder="Select Project/Styleguide"
     />

--- a/src/client/containers/ZeplinAuthEndContainer/ZeplinAuthEndContainer.tsx
+++ b/src/client/containers/ZeplinAuthEndContainer/ZeplinAuthEndContainer.tsx
@@ -1,10 +1,9 @@
 import React, { FunctionComponent, useEffect } from "react";
 import { useRouter } from "next/router";
 import * as microsoftTeams from "@microsoft/teams-js";
-import Axios from "axios";
 import { Loader } from "@fluentui/react-northstar";
 
-import { BASE_URL } from "../../config";
+import { getAccessToken } from "../../requester";
 
 export const ZeplinAuthEndContainer: FunctionComponent = () => {
     const {
@@ -22,7 +21,7 @@ export const ZeplinAuthEndContainer: FunctionComponent = () => {
             }
 
             try {
-                const { data: { accessToken } } = await Axios.post(`${BASE_URL}/api/auth/token`, { code });
+                const accessToken = await getAccessToken(String(code));
                 microsoftTeams.authentication.notifySuccess(accessToken);
             } catch (e) {
                 if (e.response) {

--- a/src/client/requester.ts
+++ b/src/client/requester.ts
@@ -1,5 +1,9 @@
 import Axios from "axios";
-import { BASE_URL } from "./config";
+
+export const getAccessToken = async (code: string): Promise<string> => {
+    const { data: { accessToken } } = await Axios.post("/api/auth/token", { code });
+    return accessToken;
+};
 
 export interface Workspace {
     id: string;
@@ -8,7 +12,41 @@ export interface Workspace {
 
 export const getWorkspaces = async (accessToken: string): Promise<Workspace[]> => {
     const { data: result } = await Axios.get(
-        `${BASE_URL}/api/workspaces`,
+        "/api/workspaces",
+        {
+            headers: {
+                Authorization: `Bearer ${accessToken}`
+            }
+        }
+    );
+    return result;
+};
+
+export interface Project {
+    id: string;
+    name: string;
+}
+
+export const getProjects = async (workspaceId: string, accessToken: string): Promise<Project[]> => {
+    const { data: result } = await Axios.get(
+        `/api/workspaces/${workspaceId}/projects`,
+        {
+            headers: {
+                Authorization: `Bearer ${accessToken}`
+            }
+        }
+    );
+    return result;
+};
+
+export interface Styleguide {
+    id: string;
+    name: string;
+}
+
+export const getStyleguides = async (workspaceId: string, accessToken: string): Promise<Styleguide[]> => {
+    const { data: result } = await Axios.get(
+        `/api/workspaces/${workspaceId}/styleguides`,
         {
             headers: {
                 Authorization: `Bearer ${accessToken}`

--- a/src/server/features/workspaceFeature/project/index.ts
+++ b/src/server/features/workspaceFeature/project/index.ts
@@ -1,0 +1,1 @@
+export * from "./projectRouter";

--- a/src/server/features/workspaceFeature/project/projectController.ts
+++ b/src/server/features/workspaceFeature/project/projectController.ts
@@ -1,0 +1,11 @@
+import { RequestHandler } from "express";
+import { projectFacade } from "./projectFacade";
+
+export const handleProjectsGet: RequestHandler = async (req, res, next) => {
+    try {
+        const result = await projectFacade.list();
+        res.json(result);
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/server/features/workspaceFeature/project/projectFacade.ts
+++ b/src/server/features/workspaceFeature/project/projectFacade.ts
@@ -1,0 +1,16 @@
+interface Project {
+    id: string;
+    name: string;
+}
+
+class ProjectFacade {
+    list(): Promise<Project[]> {
+        return Promise.resolve([
+            { id: "507f191e810c19729de860ea", name: "Project X" },
+            { id: "5f3cdb0b9c258b2b085afefe", name: "Project Y" },
+            { id: "5f3cdb11dd66f73edf5a2449", name: "Project Z" }
+        ]);
+    }
+}
+
+export const projectFacade = new ProjectFacade();

--- a/src/server/features/workspaceFeature/project/projectRouter.ts
+++ b/src/server/features/workspaceFeature/project/projectRouter.ts
@@ -1,0 +1,10 @@
+import { Router as createRouter } from "express";
+
+import { handleProjectsGet } from "./projectController";
+
+const projectRouter = createRouter();
+projectRouter.get("/", handleProjectsGet);
+
+export {
+    projectRouter
+};

--- a/src/server/features/workspaceFeature/styleguide/index.ts
+++ b/src/server/features/workspaceFeature/styleguide/index.ts
@@ -1,0 +1,1 @@
+export * from "./styleguideRouter";

--- a/src/server/features/workspaceFeature/styleguide/styleguideController.ts
+++ b/src/server/features/workspaceFeature/styleguide/styleguideController.ts
@@ -1,0 +1,11 @@
+import { RequestHandler } from "express";
+import { styleguideFacade } from "./styleguideFacade";
+
+export const handleStyleguidesGet: RequestHandler = async (req, res, next) => {
+    try {
+        const result = await styleguideFacade.list();
+        res.json(result);
+    } catch (error) {
+        next(error);
+    }
+};

--- a/src/server/features/workspaceFeature/styleguide/styleguideFacade.ts
+++ b/src/server/features/workspaceFeature/styleguide/styleguideFacade.ts
@@ -1,0 +1,16 @@
+interface Styleguide {
+    id: string;
+    name: string;
+}
+
+class StyleguideFacade {
+    list(): Promise<Styleguide[]> {
+        return Promise.resolve([
+            { id: "507f191e810c19729de860ea", name: "Styleguide X" },
+            { id: "5f3cdb0b9c258b2b085afefe", name: "Styleguide Y" },
+            { id: "5f3cdb11dd66f73edf5a2449", name: "Styleguide Z" }
+        ]);
+    }
+}
+
+export const styleguideFacade = new StyleguideFacade();

--- a/src/server/features/workspaceFeature/styleguide/styleguideRouter.ts
+++ b/src/server/features/workspaceFeature/styleguide/styleguideRouter.ts
@@ -1,0 +1,10 @@
+import { Router as createRouter } from "express";
+
+import { handleStyleguidesGet } from "./styleguideController";
+
+const styleguideRouter = createRouter();
+styleguideRouter.get("/", handleStyleguidesGet);
+
+export {
+    styleguideRouter
+};

--- a/src/server/features/workspaceFeature/workspaceFacade.ts
+++ b/src/server/features/workspaceFeature/workspaceFacade.ts
@@ -1,5 +1,5 @@
 import { OrganizationRole } from "../../adapters/zeplin/Organizations";
-import { zeplin } from "../../adapters/zeplin";
+import { zeplin } from "../../adapters";
 
 interface Workspace {
     id: string;

--- a/src/server/features/workspaceFeature/workspaceRouter.ts
+++ b/src/server/features/workspaceFeature/workspaceRouter.ts
@@ -1,9 +1,31 @@
 import { Router as createRouter } from "express";
+import Joi from "@hapi/joi";
 
+import { validateRequest } from "../../middlewares";
 import { handleWorkspacesGet } from "./workspaceController";
+import { projectRouter } from "./project";
+import { styleguideRouter } from "./styleguide";
 
 const workspaceRouter = createRouter();
 workspaceRouter.get("/", handleWorkspacesGet);
+workspaceRouter.use(
+    "/:workspaceId/projects",
+    validateRequest({
+        params: Joi.object({
+            workspaceId: Joi.string().regex(/^([0-9a-f]{24}|personal)$/i)
+        })
+    }),
+    projectRouter
+);
+workspaceRouter.use(
+    "/:workspaceId/styleguides",
+    validateRequest({
+        params: Joi.object({
+            workspaceId: Joi.string().regex(/^([0-9a-f]{24}|personal)$/i)
+        })
+    }),
+    styleguideRouter
+);
 
 export {
     workspaceRouter


### PR DESCRIPTION
- Move dummy project/styleguide lists from client-side to server-side. Since the PUPPY needs improvement to get project/styleguide with workspace filter, fetching data from PUPPY is not implemented yet.
- `BASE_URL` is redundant for client-side usage. We can use relative URLs instead.
- Move the request  of getting access token from container to `requester` to manage requests in one place.