### PR TITLE
Revert "Add changing release version to CI/CD pipeline"

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -82,9 +82,6 @@ jobs:
       - name: Change latest release
         run: aws s3 cp $S3_PATH/$TARBALL $S3_PATH/microsoft-teams-app-dev-latest.tar.gz
 
-      - name: Change the release version
-        run: aws opsworks --region $AWS_REGION update-app --app-id $AWS_APP_ID --environment Key=NEXT_PUBLIC_VERSION,Value=0.0.0-${GITHUB_SHA},Secure=false
-
       - name: Deploy
         run: >
           aws opsworks --region $AWS_REGION create-deployment --stack-id $AWS_STACK_ID --layer-ids $AWS_LAYER_ID --app-id $AWS_APP_ID --command "{\"Name\":\"deploy\"}" --custom-json "{\"zeplin\": {\"app_shortname\":\"zeplin_microsoft_teams_app\"}}"

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -87,9 +87,6 @@ jobs:
       - name: Change latest release
         run: aws s3 cp $S3_PATH/$TARBALL $S3_PATH/microsoft-teams-app-prod-latest.tar.gz
 
-      - name: Change the release version
-        run: aws opsworks --region $AWS_REGION update-app --app-id $AWS_APP_ID --environment Key=NEXT_PUBLIC_VERSION,Value=${GITHUB_REF#refs/tags/v},Secure=false
-
       - name: Deploy
         run: >
           aws opsworks --region $AWS_REGION create-deployment --stack-id $AWS_STACK_ID --layer-ids $AWS_LAYER_ID --app-id $AWS_APP_ID --command "{\"Name\":\"deploy\"}" --custom-json "{\"zeplin\": {\"app_shortname\":\"zeplin_microsoft_teams_app\"}}"


### PR DESCRIPTION
Reverts zeplin/microsoft-teams-app#62

Sadly, this command overwrites all environment variables of the app. There are some other people raising this as an issue but it seems there's no way to keep existing variables while adding/updating a single variable. See the following issue:
https://github.com/aws/aws-cli/issues/1315

Reverting this for now. We can look for a better solution in the future.