### PR TITLE
Fix channel name representation

### DIFF
--- a/src/client/containers/ConfigurationContainer/components/Configuration/ConfigurationCreate.tsx
+++ b/src/client/containers/ConfigurationContainer/components/Configuration/ConfigurationCreate.tsx
@@ -62,7 +62,7 @@ export const ConfigurationCreate: FunctionComponent<ConfigurationCreateProps> = 
         <Flex fill column gap="gap.small">
             <Text weight="semibold">
                 {"You are connecting "}
-                <Text weight="bold">#{channelName}</Text>
+                <Text weight="bold">{channelName}</Text>
                 {username
                     ? (
                         <>

--- a/src/client/containers/ConfigurationContainer/components/Configuration/ConfigurationUpdate.tsx
+++ b/src/client/containers/ConfigurationContainer/components/Configuration/ConfigurationUpdate.tsx
@@ -38,7 +38,7 @@ export const ConfigurationUpdate: FunctionComponent<ConfigurationUpdateProps> = 
             <Text weight="semibold">
                 <Text weight="bold">{resource.name}</Text>
                 {` ${resourceTypeToText(resource.type)} is connected to `}
-                <Text weight="bold">#{channelName}</Text>
+                <Text weight="bold">{channelName}</Text>
                 {" channel."}
             </Text>
         </Flex>


### PR DESCRIPTION
Teams channels don't have leading `#` symbol. 