### PR TITLE
Fix disabling mixpanel

### DIFF
--- a/src/server/adapters/mixpanel/mixpanel.ts
+++ b/src/server/adapters/mixpanel/mixpanel.ts
@@ -14,7 +14,9 @@ class Mixpanel {
         enabled
     }: MixpanelInitParams): void {
         this.enabled = enabled;
-        this.mixpanelClient = mixpanelClient.init(apiToken);
+        if (enabled) {
+            this.mixpanelClient = mixpanelClient.init(apiToken);
+        }
     }
 
     trackEvent(eventName: string, properties: mixpanelClient.PropertyDict): Promise<void> {

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -22,6 +22,8 @@ function getBooleanVariable(name: string, defaultValue: boolean): boolean {
 
 const DEFAULT_PORT = 3000;
 
+const IS_LOCAL = (process.env.NEXT_PUBLIC_ENVIRONMENT ?? "local") === "local";
+
 export const PORT = getNumberVariable("NEXT_PRIVATE_PORT", DEFAULT_PORT);
 export const {
     NEXT_PUBLIC_ENVIRONMENT: ENVIRONMENT = "local",
@@ -40,9 +42,9 @@ export const {
 } = process.env;
 
 export const IS_DEV = process.env.NODE_ENV !== "production";
-export const IS_MONGO_DEBUG = getBooleanVariable("NEXT_PRIVATE_IS_MONGO_DEBUG", IS_DEV);
-export const IS_SENTRY_ENABLED = getBooleanVariable("NEXT_PUBLIC_IS_SENTRY_ENABLED", !IS_DEV);
-export const IS_MIXPANEL_ENABLED = getBooleanVariable("NEXT_PRIVATE_IS_MIXPANEL_ENABLED", !IS_DEV);
+export const IS_MONGO_DEBUG = getBooleanVariable("NEXT_PRIVATE_IS_MONGO_DEBUG", IS_LOCAL);
+export const IS_SENTRY_ENABLED = getBooleanVariable("NEXT_PUBLIC_IS_SENTRY_ENABLED", !IS_LOCAL);
+export const IS_MIXPANEL_ENABLED = getBooleanVariable("NEXT_PRIVATE_IS_MIXPANEL_ENABLED", !IS_LOCAL);
 
 export interface Config {
     IS_MONGO_DEBUG: boolean;


### PR DESCRIPTION
Changed also disable value for boolean environment variables, since we can use a production build from local (eg. `npm run dev:prod-build`).