### PR TITLE
fix: Set fixed node versions to dev and prod workflows

### DIFF
--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -56,10 +56,10 @@ jobs:
       - name: Set `TARBALL` variable
         run: echo "TARBALL=microsoft-teams-app-dev-latest.tar.gz" >> $GITHUB_ENV
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 16.13
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 16.13
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -50,10 +50,10 @@ jobs:
       - name: Set `TARBALL` variable
         run: echo "TARBALL=microsoft-teams-app-prod-${NEXT_PUBLIC_VERSION}.tar.gz" >> $GITHUB_ENV
 
-      - name: Use Node.js 16.x
+      - name: Use Node.js 16.13
         uses: actions/setup-node@v2
         with:
-          node-version: 16.x
+          node-version: 16.13
           cache: 'npm'
 
       - name: Install npm cache


### PR DESCRIPTION
## Change description

about downgrading ci version:

A newer version of npm is bundled with node 16.6.x, npm@8.6.0 resolves many bugs regarding peer dependency resolution. On our current build @fluentui/react-northstar depends on react 16 while next.js depends on react 17 which causes a peer dependency conflict.

Resolving this problem requires the former package to be updated and will involve all components used in the project to be tested again. We can skip that for now to prioritize log migration.

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and it follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format and breaking change indicator if required (You can use the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type))
- [ ] Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
