### PR TITLE
fix: Fix type issues occured after `npm audit fix`

### DIFF
--- a/src/server/adapters/context/contexts.ts
+++ b/src/server/adapters/context/contexts.ts
@@ -1,6 +1,6 @@
 import { Context } from "./context";
 
-export interface LoggerContext {
+export type LoggerContext = {
     correlationId: string;
 }
 

--- a/src/server/adapters/logger/errorTracker.ts
+++ b/src/server/adapters/logger/errorTracker.ts
@@ -64,7 +64,7 @@ const getSentry = ({ sentryDSN, environment, version }: SentryGetParams): ErrorT
         captureError: (error, { meta, context }): void => {
             withScope(scope => {
                 if (meta) {
-                    scope.setContext("Meta", meta);
+                    scope.setContext("Meta", meta as Record<string, unknown>);
                 }
 
                 if (context) {


### PR DESCRIPTION
## Change description

Fix type issues occured after `npm audit fix`. Errors listed below:
```
○  (Static)  automatically rendered as static HTML (uses no initial props)

src/server/adapters/logger/errorTracker.ts:67:46 - error TS2345: Argument of type 'object' is not assignable to parameter of type 'Context | null'.
  Type 'object' is not assignable to type 'Context'.
    Index signature for type 'string' is missing in type '{}'.

67                     scope.setContext("Meta", meta);
                                                ~~~~

src/server/adapters/logger/errorTracker.ts:71:49 - error TS2345: Argument of type 'LoggerContext' is not assignable to parameter of type 'Context'.
  Index signature for type 'string' is missing in type 'LoggerContext'.

71                     scope.setContext("Context", context);
                                                   ~~~~~~~


Found 2 errors.
```

See the Github action result here: https://github.com/zeplin/microsoft-teams-app/actions/runs/11780335273

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and it follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format and breaking change indicator if required (You can use the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type))
- [ ] Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
