### PR TITLE
[WIP] build: npm audit december 2024

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "http-status-codes": "^1.4.0",
         "http-terminator": "^3.2.0",
         "mixpanel": "^0.13.0",
-        "mongoose": "7.6.7",
+        "mongoose": "7.8.3",
         "newrelic": "8.14.0",
         "next": "^12.0.5",
         "patch-package": "^6.2.2",
@@ -2748,9 +2748,9 @@
       "integrity": "sha512-5utMOMWXdNq0cV8hGIZEUpUVChoasoYjBOItgFIKE2a4vavmzlhra+GNXMdpvlYlv6/r7ORtVCQUDFJvPTVj2Q=="
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
-      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
       "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
@@ -11515,9 +11515,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
-      "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "dependencies": {
         "bson": "^5.5.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -11564,13 +11564,13 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.7",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.7.tgz",
-      "integrity": "sha512-6Ihl7Y7OlSEMiwyjar3N8sMKRZa3LNGcayES8I+Hluo0sV6j1SVOo8MXXnwi+z3+Hcyk4zO47+xL87fBTNlWVw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.3.tgz",
+      "integrity": "sha512-eFnbkKgyVrICoHB6tVJ4uLanS7d5AIo/xHkEbQeOv6g2sD7gh/1biRwvFifsmbtkIddQVNr3ROqHik6gkknN3g==",
       "dependencies": {
         "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.1",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
@@ -18422,9 +18422,9 @@
       "integrity": "sha512-5utMOMWXdNq0cV8hGIZEUpUVChoasoYjBOItgFIKE2a4vavmzlhra+GNXMdpvlYlv6/r7ORtVCQUDFJvPTVj2Q=="
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.1.tgz",
-      "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
@@ -25149,9 +25149,9 @@
       }
     },
     "mongodb": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
-      "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.2.tgz",
+      "integrity": "sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==",
       "requires": {
         "@mongodb-js/saslprep": "^1.1.0",
         "bson": "^5.5.0",
@@ -25169,13 +25169,13 @@
       }
     },
     "mongoose": {
-      "version": "7.6.7",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.7.tgz",
-      "integrity": "sha512-6Ihl7Y7OlSEMiwyjar3N8sMKRZa3LNGcayES8I+Hluo0sV6j1SVOo8MXXnwi+z3+Hcyk4zO47+xL87fBTNlWVw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.8.3.tgz",
+      "integrity": "sha512-eFnbkKgyVrICoHB6tVJ4uLanS7d5AIo/xHkEbQeOv6g2sD7gh/1biRwvFifsmbtkIddQVNr3ROqHik6gkknN3g==",
       "requires": {
         "bson": "^5.5.0",
         "kareem": "2.5.1",
-        "mongodb": "5.9.1",
+        "mongodb": "5.9.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7138,9 +7138,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7161,7 +7161,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -7176,6 +7176,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -11621,9 +11625,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
@@ -12696,9 +12700,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -21765,9 +21769,9 @@
       }
     },
     "express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -21788,7 +21792,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -25215,9 +25219,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -25988,9 +25992,9 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "path-type": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "http-status-codes": "^1.4.0",
     "http-terminator": "^3.2.0",
     "mixpanel": "^0.13.0",
-    "mongoose": "7.6.7",
+    "mongoose": "7.8.3",
     "newrelic": "8.14.0",
     "next": "^12.0.5",
     "patch-package": "^6.2.2",


### PR DESCRIPTION
## Change description

<details>
<summary>Before</summary>

```
# npm audit report

@sentry/browser  <7.119.1
Severity: moderate
Sentry SDK Prototype Pollution gadget in JavaScript SDKs - https://github.com/advisories/GHSA-593m-55hh-j8gv
fix available via `npm audit fix --force`
Will install @sentry/browser@8.45.0, which is a breaking change
node_modules/@sentry/browser

braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/braces
  micromatch  <=4.0.7
  Depends on vulnerable versions of braces
  node_modules/sane/node_modules/micromatch
    anymatch  1.2.0 - 2.0.0
    Depends on vulnerable versions of micromatch
    node_modules/sane/node_modules/anymatch
      sane  1.5.0 - 4.1.0
      Depends on vulnerable versions of anymatch
      Depends on vulnerable versions of micromatch
      node_modules/sane
        jest-haste-map  24.0.0-alpha.0 - 26.6.2
        Depends on vulnerable versions of sane
        node_modules/jest-haste-map
          @jest/core  <=26.6.3
          Depends on vulnerable versions of jest-config
          Depends on vulnerable versions of jest-haste-map
          Depends on vulnerable versions of jest-snapshot
          node_modules/@jest/core
            jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-cli
            node_modules/jest
            jest-cli  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-config
            node_modules/jest-cli
          @jest/reporters  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/reporters
          @jest/test-sequencer  <=26.6.3
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/test-sequencer
            jest-config  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/test-sequencer
            Depends on vulnerable versions of jest-jasmine2
            node_modules/@jest/core/node_modules/jest-config
            node_modules/jest-cli/node_modules/jest-config
            node_modules/jest-runner/node_modules/jest-config
            node_modules/jest-runtime/node_modules/jest-config
              jest-runner  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              node_modules/jest-runner
              jest-runtime  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of @jest/transform
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-runtime
                jest-jasmine2  24.2.0-alpha.0 - 26.6.3
                Depends on vulnerable versions of jest-runtime
                Depends on vulnerable versions of jest-snapshot
                node_modules/jest-jasmine2
          @jest/transform  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/transform
            babel-jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            node_modules/babel-jest
          jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/jest-snapshot
            jest-resolve-dependencies  26.1.0 - 26.6.3
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-resolve-dependencies

cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
fix available via `npm audit fix --force`
Will install @sentry/node@8.45.0, which is a breaking change
node_modules/cookie
  @sentry/node  4.0.0-beta.0 - 7.74.2-alpha.1
  Depends on vulnerable versions of cookie
  node_modules/@sentry/node

micromatch  <=4.0.7
Severity: high
Regular Expression Denial of Service (ReDoS) in micromatch - https://github.com/advisories/GHSA-952p-6rrq-rcjv
Depends on vulnerable versions of braces
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/micromatch
  anymatch  1.2.0 - 2.0.0
  Depends on vulnerable versions of micromatch
  node_modules/sane/node_modules/anymatch
    sane  1.5.0 - 4.1.0
    Depends on vulnerable versions of anymatch
    Depends on vulnerable versions of micromatch
    node_modules/sane
      jest-haste-map  24.0.0-alpha.0 - 26.6.2
      Depends on vulnerable versions of sane
      node_modules/jest-haste-map
        @jest/core  <=26.6.3
        Depends on vulnerable versions of jest-config
        Depends on vulnerable versions of jest-haste-map
        Depends on vulnerable versions of jest-snapshot
        node_modules/@jest/core
          jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-cli
          node_modules/jest
          jest-cli  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-config
          node_modules/jest-cli
        @jest/reporters  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/reporters
        @jest/test-sequencer  <=26.6.3
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/test-sequencer
          jest-config  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/test-sequencer
          Depends on vulnerable versions of jest-jasmine2
          node_modules/@jest/core/node_modules/jest-config
          node_modules/jest-cli/node_modules/jest-config
          node_modules/jest-runner/node_modules/jest-config
          node_modules/jest-runtime/node_modules/jest-config
            jest-runner  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            node_modules/jest-runner
            jest-runtime  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-runtime
              jest-jasmine2  24.2.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-runtime
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-jasmine2
        @jest/transform  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/transform
          babel-jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/transform
          node_modules/babel-jest
        jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/jest-snapshot
          jest-resolve-dependencies  26.1.0 - 26.6.3
          Depends on vulnerable versions of jest-snapshot
          node_modules/jest-resolve-dependencies

next  0.9.9 - 14.2.6
Severity: moderate
Next.js missing cache-control header may lead to CDN caching empty reply - https://github.com/advisories/GHSA-c59h-r6p8-q9wc
Denial of Service condition in Next.js image optimization - https://github.com/advisories/GHSA-g77x-44xx-532m
Depends on vulnerable versions of postcss
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/next

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/postcss
  next  0.9.9 - 14.2.6
  Depends on vulnerable versions of postcss
  node_modules/next

23 vulnerabilities (2 low, 19 moderate, 2 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
➜  microsoft-teams-app git:(build/npm-audit-december-2024) gco main
Switched to branch 'main'
Your branch is up to date with 'origin/main'.
➜  microsoft-teams-app git:(main) npm audit
# npm audit report

@sentry/browser  <7.119.1
Severity: moderate
Sentry SDK Prototype Pollution gadget in JavaScript SDKs - https://github.com/advisories/GHSA-593m-55hh-j8gv
fix available via `npm audit fix --force`
Will install @sentry/browser@8.45.0, which is a breaking change
node_modules/@sentry/browser

braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/braces
  micromatch  <=4.0.7
  Depends on vulnerable versions of braces
  node_modules/sane/node_modules/micromatch
    anymatch  1.2.0 - 2.0.0
    Depends on vulnerable versions of micromatch
    node_modules/sane/node_modules/anymatch
      sane  1.5.0 - 4.1.0
      Depends on vulnerable versions of anymatch
      Depends on vulnerable versions of micromatch
      node_modules/sane
        jest-haste-map  24.0.0-alpha.0 - 26.6.2
        Depends on vulnerable versions of sane
        node_modules/jest-haste-map
          @jest/core  <=26.6.3
          Depends on vulnerable versions of jest-config
          Depends on vulnerable versions of jest-haste-map
          Depends on vulnerable versions of jest-snapshot
          node_modules/@jest/core
            jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-cli
            node_modules/jest
            jest-cli  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-config
            node_modules/jest-cli
          @jest/reporters  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/reporters
          @jest/test-sequencer  <=26.6.3
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/test-sequencer
            jest-config  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/test-sequencer
            Depends on vulnerable versions of jest-jasmine2
            node_modules/@jest/core/node_modules/jest-config
            node_modules/jest-cli/node_modules/jest-config
            node_modules/jest-runner/node_modules/jest-config
            node_modules/jest-runtime/node_modules/jest-config
              jest-runner  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              node_modules/jest-runner
              jest-runtime  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of @jest/transform
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-runtime
                jest-jasmine2  24.2.0-alpha.0 - 26.6.3
                Depends on vulnerable versions of jest-runtime
                Depends on vulnerable versions of jest-snapshot
                node_modules/jest-jasmine2
          @jest/transform  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/transform
            babel-jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            node_modules/babel-jest
          jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/jest-snapshot
            jest-resolve-dependencies  26.1.0 - 26.6.3
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-resolve-dependencies

cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
fix available via `npm audit fix --force`
Will install @sentry/node@8.45.0, which is a breaking change
node_modules/cookie
  @sentry/node  4.0.0-beta.0 - 7.74.2-alpha.1
  Depends on vulnerable versions of cookie
  node_modules/@sentry/node

micromatch  <=4.0.7
Severity: high
Regular Expression Denial of Service (ReDoS) in micromatch - https://github.com/advisories/GHSA-952p-6rrq-rcjv
Depends on vulnerable versions of braces
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/micromatch
  anymatch  1.2.0 - 2.0.0
  Depends on vulnerable versions of micromatch
  node_modules/sane/node_modules/anymatch
    sane  1.5.0 - 4.1.0
    Depends on vulnerable versions of anymatch
    Depends on vulnerable versions of micromatch
    node_modules/sane
      jest-haste-map  24.0.0-alpha.0 - 26.6.2
      Depends on vulnerable versions of sane
      node_modules/jest-haste-map
        @jest/core  <=26.6.3
        Depends on vulnerable versions of jest-config
        Depends on vulnerable versions of jest-haste-map
        Depends on vulnerable versions of jest-snapshot
        node_modules/@jest/core
          jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-cli
          node_modules/jest
          jest-cli  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-config
          node_modules/jest-cli
        @jest/reporters  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/reporters
        @jest/test-sequencer  <=26.6.3
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/test-sequencer
          jest-config  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/test-sequencer
          Depends on vulnerable versions of jest-jasmine2
          node_modules/@jest/core/node_modules/jest-config
          node_modules/jest-cli/node_modules/jest-config
          node_modules/jest-runner/node_modules/jest-config
          node_modules/jest-runtime/node_modules/jest-config
            jest-runner  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            node_modules/jest-runner
            jest-runtime  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-runtime
              jest-jasmine2  24.2.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-runtime
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-jasmine2
        @jest/transform  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/transform
          babel-jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/transform
          node_modules/babel-jest
        jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/jest-snapshot
          jest-resolve-dependencies  26.1.0 - 26.6.3
          Depends on vulnerable versions of jest-snapshot
          node_modules/jest-resolve-dependencies

mongoose  7.0.0-rc0 - 7.8.2
Severity: high
Mongoose search injection vulnerability - https://github.com/advisories/GHSA-m7xq-9374-9rvx
fix available via `npm audit fix --force`
Will install mongoose@7.8.3, which is outside the stated dependency range
node_modules/mongoose

nanoid  <3.3.8
Infinite loop in nanoid - https://github.com/advisories/GHSA-mwcw-c2x4-8c55
fix available via `npm audit fix`
node_modules/nanoid

next  0.9.9 - 14.2.6
Severity: moderate
Next.js missing cache-control header may lead to CDN caching empty reply - https://github.com/advisories/GHSA-c59h-r6p8-q9wc
Denial of Service condition in Next.js image optimization - https://github.com/advisories/GHSA-g77x-44xx-532m
Depends on vulnerable versions of postcss
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/next

path-to-regexp  <0.1.12
Severity: moderate
Unpatched `path-to-regexp` ReDoS in 0.1.x - https://github.com/advisories/GHSA-rhx6-c78j-4q9w
fix available via `npm audit fix`
node_modules/path-to-regexp
  express  4.0.0-rc1 - 4.21.1 || 5.0.0-alpha.1 - 5.0.0-beta.3
  Depends on vulnerable versions of path-to-regexp
  node_modules/express

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/postcss
  next  0.9.9 - 14.2.6
  Depends on vulnerable versions of postcss
  node_modules/next

27 vulnerabilities (3 low, 21 moderate, 3 high)

```
</details>


<details>
<summary>After</summary>

```
# npm audit report

@sentry/browser  <7.119.1
Severity: moderate
Sentry SDK Prototype Pollution gadget in JavaScript SDKs - https://github.com/advisories/GHSA-593m-55hh-j8gv
fix available via `npm audit fix --force`
Will install @sentry/browser@8.45.0, which is a breaking change
node_modules/@sentry/browser

braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/braces
  micromatch  <=4.0.7
  Depends on vulnerable versions of braces
  node_modules/sane/node_modules/micromatch
    anymatch  1.2.0 - 2.0.0
    Depends on vulnerable versions of micromatch
    node_modules/sane/node_modules/anymatch
      sane  1.5.0 - 4.1.0
      Depends on vulnerable versions of anymatch
      Depends on vulnerable versions of micromatch
      node_modules/sane
        jest-haste-map  24.0.0-alpha.0 - 26.6.2
        Depends on vulnerable versions of sane
        node_modules/jest-haste-map
          @jest/core  <=26.6.3
          Depends on vulnerable versions of jest-config
          Depends on vulnerable versions of jest-haste-map
          Depends on vulnerable versions of jest-snapshot
          node_modules/@jest/core
            jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-cli
            node_modules/jest
            jest-cli  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/core
            Depends on vulnerable versions of jest-config
            node_modules/jest-cli
          @jest/reporters  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/reporters
          @jest/test-sequencer  <=26.6.3
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/test-sequencer
            jest-config  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/test-sequencer
            Depends on vulnerable versions of babel-jest
            Depends on vulnerable versions of jest-jasmine2
            node_modules/@jest/core/node_modules/jest-config
            node_modules/jest-cli/node_modules/jest-config
            node_modules/jest-runner/node_modules/jest-config
            node_modules/jest-runtime/node_modules/jest-config
              jest-runner  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              node_modules/jest-runner
              jest-runtime  24.0.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of @jest/transform
              Depends on vulnerable versions of jest-config
              Depends on vulnerable versions of jest-haste-map
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-runtime
                jest-jasmine2  24.2.0-alpha.0 - 26.6.3
                Depends on vulnerable versions of jest-runtime
                Depends on vulnerable versions of jest-snapshot
                node_modules/jest-jasmine2
          @jest/transform  <=26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/@jest/transform
            babel-jest  24.2.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            node_modules/babel-jest
          jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
          Depends on vulnerable versions of jest-haste-map
          node_modules/jest-snapshot
            jest-resolve-dependencies  26.1.0 - 26.6.3
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-resolve-dependencies

cookie  <0.7.0
cookie accepts cookie name, path, and domain with out of bounds characters - https://github.com/advisories/GHSA-pxg6-pf52-xh8x
fix available via `npm audit fix --force`
Will install @sentry/node@8.45.0, which is a breaking change
node_modules/cookie
  @sentry/node  4.0.0-beta.0 - 7.74.2-alpha.1
  Depends on vulnerable versions of cookie
  node_modules/@sentry/node

micromatch  <=4.0.7
Severity: high
Regular Expression Denial of Service (ReDoS) in micromatch - https://github.com/advisories/GHSA-952p-6rrq-rcjv
Depends on vulnerable versions of braces
fix available via `npm audit fix --force`
Will install jest@29.7.0, which is a breaking change
node_modules/sane/node_modules/micromatch
  anymatch  1.2.0 - 2.0.0
  Depends on vulnerable versions of micromatch
  node_modules/sane/node_modules/anymatch
    sane  1.5.0 - 4.1.0
    Depends on vulnerable versions of anymatch
    Depends on vulnerable versions of micromatch
    node_modules/sane
      jest-haste-map  24.0.0-alpha.0 - 26.6.2
      Depends on vulnerable versions of sane
      node_modules/jest-haste-map
        @jest/core  <=26.6.3
        Depends on vulnerable versions of jest-config
        Depends on vulnerable versions of jest-haste-map
        Depends on vulnerable versions of jest-snapshot
        node_modules/@jest/core
          jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-cli
          node_modules/jest
          jest-cli  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/core
          Depends on vulnerable versions of jest-config
          node_modules/jest-cli
        @jest/reporters  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/reporters
        @jest/test-sequencer  <=26.6.3
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/test-sequencer
          jest-config  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/test-sequencer
          Depends on vulnerable versions of babel-jest
          Depends on vulnerable versions of jest-jasmine2
          node_modules/@jest/core/node_modules/jest-config
          node_modules/jest-cli/node_modules/jest-config
          node_modules/jest-runner/node_modules/jest-config
          node_modules/jest-runtime/node_modules/jest-config
            jest-runner  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            node_modules/jest-runner
            jest-runtime  24.0.0-alpha.0 - 26.6.3
            Depends on vulnerable versions of @jest/transform
            Depends on vulnerable versions of jest-config
            Depends on vulnerable versions of jest-haste-map
            Depends on vulnerable versions of jest-snapshot
            node_modules/jest-runtime
              jest-jasmine2  24.2.0-alpha.0 - 26.6.3
              Depends on vulnerable versions of jest-runtime
              Depends on vulnerable versions of jest-snapshot
              node_modules/jest-jasmine2
        @jest/transform  <=26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/@jest/transform
          babel-jest  24.2.0-alpha.0 - 26.6.3
          Depends on vulnerable versions of @jest/transform
          node_modules/babel-jest
        jest-snapshot  24.2.0-alpha.0 - 24.5.0 || 26.1.0 - 26.6.2
        Depends on vulnerable versions of jest-haste-map
        node_modules/jest-snapshot
          jest-resolve-dependencies  26.1.0 - 26.6.3
          Depends on vulnerable versions of jest-snapshot
          node_modules/jest-resolve-dependencies

next  0.9.9 - 14.2.6
Severity: moderate
Next.js missing cache-control header may lead to CDN caching empty reply - https://github.com/advisories/GHSA-c59h-r6p8-q9wc
Denial of Service condition in Next.js image optimization - https://github.com/advisories/GHSA-g77x-44xx-532m
Depends on vulnerable versions of postcss
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/next

postcss  <8.4.31
Severity: moderate
PostCSS line return parsing error - https://github.com/advisories/GHSA-7fh5-64p2-3v2j
fix available via `npm audit fix --force`
Will install next@15.1.0, which is a breaking change
node_modules/postcss
  next  0.9.9 - 14.2.6
  Depends on vulnerable versions of postcss
  node_modules/next

23 vulnerabilities (2 low, 19 moderate, 2 high)
```

</details>

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]()

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review

- [ ] Pull request has a descriptive title and it follows [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) format and breaking change indicator if required (You can use the [Angular convention](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type))
- [ ] Screenshots or screencasts are attached as necessary
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
